### PR TITLE
fix compile select when columns is null

### DIFF
--- a/src/Jfelder/OracleDB/Query/Grammars/OracleGrammar.php
+++ b/src/Jfelder/OracleDB/Query/Grammars/OracleGrammar.php
@@ -19,6 +19,8 @@ class OracleGrammar extends \Illuminate\Database\Query\Grammars\Grammar {
 	 */
 	public function compileSelect(Builder $query)
 	{
+		if (is_null($query->columns)) $query->columns = array('*');
+
 		$components = $this->compileComponents($query);
 
 		// If an offset is present on the query, we will need to wrap the query in
@@ -29,7 +31,7 @@ class OracleGrammar extends \Illuminate\Database\Query\Grammars\Grammar {
 			return $this->compileAnsiOffset($query, $components);
 		}
 
-		return $this->concatenate($components);
+		return trim($this->concatenate($components));
 	}
 
         


### PR DESCRIPTION
When using Eloquent model, the select statement generated is invalid.

``` php
$query = new Demo;
$query->select('*');
echo $query->toSql();
```

Expected SQL:
`select * from demos`

Actual SQL:
`from demos where`
