### PR TITLE
Fix typo in code

### DIFF
--- a/src/Jfelder/OracleDB/Schema/OracleBuilder.php
+++ b/src/Jfelder/OracleDB/Schema/OracleBuilder.php
@@ -2,7 +2,7 @@
 
 namespace Jfelder\OracleDB\Schema;
 
-class OracleBuilder extends \Illuminate\Database\Schema\Buidler
+class OracleBuilder extends \Illuminate\Database\Schema\Builder
 {
     /**
      * Determine if the given table exists.
@@ -29,7 +29,7 @@ class OracleBuilder extends \Illuminate\Database\Schema\Buidler
      */
     public function getColumnListing($table)
     {
-        $sql = $this->grammar->compileColumnExists();
+        $sql = $this->grammar->compileColumnExists($table);
 
         $database = $this->connection->getDatabaseName();
 


### PR DESCRIPTION
Hi,

I found 2 typo error in the class OracleBuilder that causes errors when running with laravel 5.1 and php 5.6.

Wrong extended class name. OracleBuilder extends \Illuminate\Database\Schema\Buidler instead of \Illuminate\Database\Schema\Builder

In the getColumnListing function, the invocation of $this->grammar->compileColumnExists(); should receive the $table variable as paramter.